### PR TITLE
fix(webpack-client-prod): keep keyframes names

### DIFF
--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -191,7 +191,13 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
         }),
         new ManifestPlugin(),
         new webpack.optimize.ModuleConcatenationPlugin(),
-        new OptimizeCssAssetsPlugin(),
+        new OptimizeCssAssetsPlugin({
+            cssProcessorOptions: {
+                reduceIdents: {
+                    keyframes: false
+                }
+            }
+        }),
         new CompressionPlugin({
             asset: '[file].gz',
             algorithm: 'gzip',


### PR DESCRIPTION
see https://github.com/alfa-laboratory/arui-presets/pull/232