### PR TITLE
improve postcss overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,27 @@ module.exports = {
 - `babel-server` - конфигурация `babel` для серверноого кода. Ключи: `babel`, `babelServer`.
 - `dev-server` - конфигурация `webpack-dev-server`. Ключи: `devServer`.
 - `postcss` - конфигурация для `postcss`. Ключи: `postcss`.
+  > `config` postcss содержит массив с уже инициализированными плагинами, параметры которых уже зафиксированны. Если необходимо изменить параметры плагинов можно пересоздать конфиг, таким образом:
+    ```javascript
+    const {
+        createPostcssConfig, // функция для создания конфигурационного файла postcss
+        postcssPlugins, // список плагинов
+        postcssPluginsOptions, // коллекция конфигураций плагинов
+    } = require('arui-scripts/configs/postcss.config');
+
+    module.exports = {
+        postcss: () => {
+            const newOption = {
+                ...postcssPluginsOptions,
+                'postcss-import': {
+                    ...postcssPluginsOptions['postcss-import'],
+                    path: [...postcssPluginsOptions['postcss-import'].path, './src'],
+                },
+            };
+            return createPostcssConfig(postcssPlugins, newOption);
+        },
+    };
+    ```
 - `stats-options` - конфигурация для [webpack-stats](https://webpack.js.org/configuration/stats/). Ключи: `stats`.
 - `webpack.client.dev` - конфигурация для клиентского webpack в dev режиме. Ключи: `webpack`, `webpackClient`, `webpackDev`, `webpackClientDev`.
 - `webpack.client.prod` - конфигурация для клиентского webpack в prod режиме. Ключи: `webpack`, `webpackClient`, `webpackProd`, `webpackClientProd`.
@@ -371,3 +392,4 @@ module.exports = {
 - `webpack.server.prod` - конфигурация для серверного webpack в prod режиме. Ключи: `webpack`, `webpackServer`, `webpackProd`, `webpackServerProd`.
 
 Для некоторых конфигураций определены несколько ключей, они будут применятся в том порядке, в котором они приведены в этом файле.
+

--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -1,3 +1,9 @@
+/**
+ * Функция для создания конфигурационного файла postcss
+ * @param {String[]} plugins список плагинов
+ * @param {Object} options коллекция конфигураций плагинов, где ключ - название плагина, а значение - аргумент для инициализации
+ * @returns {*}
+ */
 function createPostcssConfig(plugins, options) {
     return plugins.map(pluginName => {
         const plugin = require(pluginName);

--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -1,0 +1,56 @@
+function createPostcssConfig(plugins, options) {
+    return plugins.map(pluginName => {
+        const plugin = require(pluginName);
+
+        if (options.hasOwnProperty(pluginName)) {
+            return plugin(options[pluginName]);
+        }
+        return plugin();
+    });
+}
+
+const postcssPlugins = [
+    'postcss-omit-import-tilde',
+    'postcss-import',
+    'postcss-url',
+    'postcss-mixins',
+    'postcss-for',
+    'postcss-each',
+    'postcss-custom-media',
+    'postcss-custom-properties',
+    'postcss-strip-units',
+    'postcss-calc',
+    'postcss-color-function',
+    'postcss-nested',
+    'autoprefixer',
+    'postcss-inherit',
+];
+
+const postcssPluginsOptions = {
+    'postcss-import': {
+        path: ['./src'],
+        plugins: [require('postcss-discard-comments')()],
+    },
+    'postcss-url': {
+        url: 'rebase',
+    },
+    'postcss-custom-media': {
+        extensions: {
+            '--small': 'screen',
+            '--small-only': 'screen and (max-width: 47.9375em)',
+            '--medium': 'screen and (min-width: 48em)',
+            '--medium-only': 'screen and (min-width: 48em) and (max-width: 64em)',
+            '--large': 'screen and (min-width: 64.0625em)',
+            '--large-only': 'screen and (min-width: 64.0625em) and (max-width: 90em)',
+            '--xlarge': 'screen and (min-width: 90.0625em)',
+            '--xlarge-only': 'screen and (min-width: 90.0625em) and (max-width: 120em)',
+            '--xxlarge': 'screen and (min-width: 120.0625em)',
+            '--xxlarge-only': 'screen and (min-width: 120.0625em) and (max-width: 99999999em)',
+        },
+    },
+    'postcss-custom-properties': {
+        preserve: false,
+    },
+};
+
+module.exports = { postcssPlugins, postcssPluginsOptions, createPostcssConfig };

--- a/configs/postcss.js
+++ b/configs/postcss.js
@@ -1,40 +1,9 @@
-const applyOverrides = require('./util/apply-overrides');
+const path = require('path');
 
-module.exports = applyOverrides('postcss', [
-    require('postcss-omit-import-tilde')(),
-    require('postcss-import')({
-        path: [],
-        plugins: [
-            require('postcss-discard-comments')()
-        ]
-    }),
-    require('postcss-url')({
-        url: 'rebase'
-    }),
-    require('postcss-mixins')(),
-    require('postcss-for')(),
-    require('postcss-each')(),
-    require('postcss-custom-media')({
-        extensions: {
-            "--small": "screen",
-            "--small-only": "screen and (max-width: 47.9375em)",
-            "--medium": "screen and (min-width: 48em)",
-            "--medium-only": "screen and (min-width: 48em) and (max-width: 64em)",
-            "--large": "screen and (min-width: 64.0625em)",
-            "--large-only": "screen and (min-width: 64.0625em) and (max-width: 90em)",
-            "--xlarge": "screen and (min-width: 90.0625em)",
-            "--xlarge-only": "screen and (min-width: 90.0625em) and (max-width: 120em)",
-            "--xxlarge": "screen and (min-width: 120.0625em)",
-            "--xxlarge-only": "screen and (min-width: 120.0625em) and (max-width: 99999999em)"
-        }
-    }),
-    require('postcss-custom-properties')({
-        preserve: false
-    }),
-    require('postcss-strip-units')(),
-    require('postcss-calc')(),
-    require('postcss-color-function')(),
-    require('postcss-nested')(),
-    require('autoprefixer')(),
-    require('postcss-inherit')
-]);
+const applyOverrides = require('./util/apply-overrides');
+const { postcssPlugins, postcssPluginsOptions, createPostcssConfig } = require('./postcss.config');
+
+module.exports = applyOverrides(
+  'postcss',
+  createPostcssConfig(postcssPlugins, postcssPluginsOptions)
+);


### PR DESCRIPTION
Пример использования
```
const {
    createPostcssConfig,
    postcssPlugins,
    postcssPluginsOptions,
} = require('arui-scripts/configs/postcss.config');

module.exports = {
    postcss: () => {
        const newOption = {
            ...postcssPluginsOptions,
            'postcss-import': {
                ...postcssPluginsOptions['postcss-import'],
                path: [...postcssPluginsOptions['postcss-import'].path, './src'],
            },
        };
        return createPostcssConfig(postcssPlugins, newOption);
    },
};
```