### PR TITLE
ADD SYMLINK TO THE PROJECT ROOT FOLDER [CODE_REVIEW]

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -7,13 +7,15 @@ const commands = [
     'docker-build',
     'test',
     'ensure-yarn',
-    'archive-build'
+    'archive-build',
+    'postinstall'
 ];
 
 const command = process.argv[2];
 
 if (!command || commands.indexOf(command) === -1) {
     console.error(`Please specify one of available commands: ${commands.map(c => `"${c}"`).join(' ')}`);
+
     process.exit(-1);
 }
 

--- a/commands/postinstall/index.js
+++ b/commands/postinstall/index.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const fs = require('fs');
+
+const { cwd } = require('../../configs/app-configs');
+
+// Change project symlink name from @ to #
+// From `yarn` developers community @see @link https://github.com/yarnpkg/yarn/issues/5709#issuecomment-426571704):
+// Oooh! That totally makes sense - if something starts with an @ we assume
+// it's an npm scope, in which case we have to recurse inside to find out the
+// actual package folders. So from Yarn point of view, @/sources is a package
+// called "sources" from the scope "@".
+const symlinkname = '#';
+// Symlink dirname
+const from = `${cwd}/node_modules`;
+// Existing path
+const to = path.relative(from, cwd);
+// Symlink file
+const symlink = `${from}/${symlinkname}`;
+
+try {
+    // Add symlink to the project root folder
+    fs.symlinkSync(to, symlink);
+} catch (err) {
+    // Show error message
+    console.log(`Error while creating symlink to ${to}\n`, err);
+} finally {
+    // Check symlink file existance, otherwise fail
+    if (fs.existsSync(symlink)) {
+        console.log(`Symlink from ${symlink} to ${to} successfully created`);
+    } else {
+        process.exit(-1);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arui-scripts",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "index.js",
   "license": "MPL-2.0",
   "repository": {
@@ -81,7 +81,7 @@
     "webpack-node-externals": "^1.6.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.9.1"
   },
   "scripts": {
     "_changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",


### PR DESCRIPTION
# Мотивация

```diff
-import { getOrganizationAccounts } from '../../actions/accounts';
+import { getOrganizationAccounts } from '@/src/actions/accounts';
-import { getNps } from '../../actions/nps';
+import { getNps } from '@/src/actions/nps';
-import { trackAlfaMetrics } from '../../actions/app';
+import { trackAlfaMetrics } from '@/src/actions/app';
-import { getGlobalNotification } from '../../actions/global-notification';
+import { getGlobalNotification } from '@/src/actions/global-notification';
-import { getFifaActionInfo } from '../../actions/fifa';
+import { getFifaActionInfo } from '@/src/actions/fifa';
```

```console
lrwxr-xr-x  1 farewell  staff  2 Oct  3 21:25 node_modules/#@ -> ..
```

## Зачем нам это?

1. Относительные пути ломаются при рефакторинге (перемещении) модулей;
2. Относительные пути вида `../../../` смотрятся некрасиво и тяжело читаемо*.

*Представьте, что у вас есть следующая структура проекта:

```console
.
├── bar.js
└── a/
    ├── bar.js
    └── b/
        └── foo.js
```

Внутри `foo.js` файла пути будут вида:

```console
import '../bar.js`
import '../../bar.js'
```

## Где можно почитать?

- [Better local require() paths for Node.js](https://gist.github.com/branneman/8048520)

P. S. I am sorry for an internal link here, but principally is the same that discussed [here](http://git.moscow.alfaintra.net/projects/CORP-DASH/repos/corp-dash-ui/pull-requests/431/overview).
