### PR TITLE
fix(webpack.client): remove pathinfo from client prod build

### DIFF
--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -25,8 +25,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
     entry: [configs.clientPolyfillsEntry, configs.clientEntry].filter(Boolean),
     context: configs.cwd,
     output: {
-        // Add /* filename */ comments to generated require()s in the output.
-        pathinfo: true,
+        pathinfo: false,
         path: configs.clientOutputPath,
         publicPath: configs.publicPath,
         filename: '[name].[chunkhash:8].js',


### PR DESCRIPTION
Удаляем лишние коменты из прод билда клиентского кода. Сейчас там куча лишних коментов