### PR TITLE
fix(test): Fixed argument handling to test provided files only

### DIFF
--- a/commands/test/index.js
+++ b/commands/test/index.js
@@ -13,6 +13,7 @@ process.on('unhandledRejection', err => {
     throw err;
 });
 
+// Skip 'node', 'arui-scripts' and 'test' arguments and take all the rest (or none if there is no more arguments).
 const argv = process.argv.slice(3);
 
 argv.push(

--- a/commands/test/index.js
+++ b/commands/test/index.js
@@ -13,7 +13,7 @@ process.on('unhandledRejection', err => {
     throw err;
 });
 
-const argv = process.argv.slice(2);
+const argv = process.argv.slice(3);
 
 argv.push(
     '--config',


### PR DESCRIPTION
Argument array is: ['node', 'arui-scripts', 'test', ...otherArguments], so `.slice(2)` takes 'test' argument as well. So provided files to be tested was ignored, and all tests have been run instead.