### PR TITLE
fix: remove toLowerCase() call on argValue from docker-build

### DIFF
--- a/commands/docker-build/index.js
+++ b/commands/docker-build/index.js
@@ -15,7 +15,7 @@ const commandLineArguments = process.argv.slice(3);
 commandLineArguments.forEach(arg => {
     let [argName, argValue] = arg.split('=');
     argName = argName.toLowerCase().trim();
-    argValue = argValue ? argValue.trim().toLowerCase() : '';
+    argValue = argValue ? argValue.trim() : '';
     switch (argName) {
         case 'version':
             imageVersion = argValue;


### PR DESCRIPTION
Убран  вызов .toLowerCase() на argValue в скрипте docker-build. Теперь имя docker image должно будет соответствовать переданным значениям.

**Мотивация и контекст**
Для сборки докер образа могут быть переданы параметры извне, затем по этим параметрам может происходить поиск созданного образа для дальнейших манипуляций. И если значения этих параметров внутри скрипта docker-build изменяются, то результат не будет соответствовать ожидаемому внешним окружением, не удастся найти образ по изначальным параметрам.