### PR TITLE
feat(webpack): remove React ProvidePlugin

### DIFF
--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -174,9 +174,6 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
     },
     plugins: [
         new AssetsPlugin({ path: configs.serverOutputPath }),
-        new webpack.ProvidePlugin({
-            React: 'react'
-        }),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
         }),

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -187,9 +187,6 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
             filename: '[name].[contenthash:8].css',
             chunkFilename: '[name].[contenthash:8].chunk.css',
         }),
-        new webpack.ProvidePlugin({
-            React: 'react'
-        }),
         new webpack.HashedModuleIdsPlugin(),
         new ManifestPlugin(),
         new OptimizeCssAssetsPlugin({

--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -154,9 +154,6 @@ const config = {
             raw: true,
             entryOnly: false
         }),
-        new webpack.ProvidePlugin({
-            React: 'react'
-        }),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
         }),

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -138,9 +138,6 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
             raw: true,
             entryOnly: false
         }),
-        new webpack.ProvidePlugin({
-            React: 'react'
-        }),
         configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin()
     ].filter(Boolean)
 });


### PR DESCRIPTION
Весь jsx превращается в вызовы React.createElement(...) при компиляции. 
То есть даже если у вас в файле нигде нету явного использования React - он должен быть заимпорчен. На данный момент даже если вы не добавляли импорт сами - он добавится с помощью WebpackProvidePlugin. 
Хочется это отключить, так как другие сборщики (например library-utils, через который либы собираются) не поддерживают такое поведение, и могут возникать не очень явные проблемы при переносе кода из проекта в либу (на проекте оно у меня работало, а тут перестало, как же так?!)
Собственно после убирания этого плагина вам придётся добавить явный импорт, если у вас его нету.