### PR TITLE
feat(*): add css modules support for *.pcss files

### DIFF
--- a/__tests__/src/app.jsx
+++ b/__tests__/src/app.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import image from './clock.svg';
 import { isSmaller } from './utils';
 
+import styles from './css-module.pcss';
 import './style.css';
 
 export class App extends React.Component {
@@ -11,7 +12,7 @@ export class App extends React.Component {
 
     render() {
         return (
-            <div>
+            <div className={ styles.root }>
                 <h2>
                     Hello, arui-scripts!
                 </h2>

--- a/__tests__/src/css-module.pcss
+++ b/__tests__/src/css-module.pcss
@@ -1,0 +1,7 @@
+.root {
+    padding: 10px;
+}
+
+:global .btn:hover {
+    animation-duration: .5s;
+}

--- a/configs/util/css-modules-local-ident.js
+++ b/configs/util/css-modules-local-ident.js
@@ -1,0 +1,5 @@
+function getLocalIdentPattern({ isProduction }) {
+    return '[name]__[local]__[hash:base64:5]';
+}
+
+module.exports = getLocalIdentPattern;

--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -6,6 +6,7 @@ const AssetsPlugin = require('assets-webpack-plugin');
 
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 
+const getLocalIdentPattern = require('./util/css-modules-local-ident');
 const configs = require('./app-configs');
 const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
@@ -137,6 +138,29 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
                                 loader: require.resolve('css-loader'),
                                 options: {
                                     importLoaders: 1,
+                                },
+                            },
+                            {
+                                loader: require.resolve('postcss-loader'),
+                                options: {
+                                    // Necessary for external CSS imports to work
+                                    // https://github.com/facebookincubator/create-react-app/issues/2677
+                                    ident: 'postcss',
+                                    plugins: () => postcssConf,
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        test: /\.pcss$/,
+                        use: [
+                            require.resolve('style-loader'),
+                            {
+                                loader: require.resolve('css-loader'),
+                                options: {
+                                    importLoaders: 1,
+                                    modules: true,
+                                    localIdentName: getLocalIdentPattern({ isProduction: false })
                                 },
                             },
                             {

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -7,6 +7,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
 
+const getLocalIdentPattern = require('./util/css-modules-local-ident');
 const configs = require('./app-configs');
 const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
@@ -145,6 +146,34 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
                                     importLoaders: 1,
                                     minimize: true,
                                     sourceMap: false,
+                                },
+                            },
+                            {
+                                loader: require.resolve('postcss-loader'),
+                                options: {
+                                    // Necessary for external CSS imports to work
+                                    // https://github.com/facebookincubator/create-react-app/issues/2677
+                                    ident: 'postcss',
+                                    plugins: () => postcssConf,
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        test: /\.pcss$/,
+                        loaders: [
+                            {
+                                loader: MiniCssExtractPlugin.loader,
+                                options: { publicPath: './' }
+                            },
+                            {
+                                loader: require.resolve('css-loader'),
+                                options: {
+                                    importLoaders: 1,
+                                    minimize: true,
+                                    modules: true,
+                                    sourceMap: false,
+                                    localIdentName: getLocalIdentPattern({ isProduction: true })
                                 },
                             },
                             {

--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -9,6 +9,7 @@ const nodeExternals = require('webpack-node-externals');
 
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 
+const getLocalIdentPattern = require('./util/css-modules-local-ident');
 const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const applyOverrides = require('./util/apply-overrides');
@@ -116,6 +117,18 @@ const config = {
                     {
                         test: /\.css$/,
                         loader: require.resolve('null-loader')
+                    },
+                    {
+                        test: /\.pcss$/,
+                        use: [
+                            {
+                                loader: require.resolve('css-loader/locals'),
+                                options: {
+                                    modules: true,
+                                    localIdentName: getLocalIdentPattern({ isProduction: false })
+                                },
+                            }
+                        ],
                     },
                     // "file" loader makes sure those assets get served by WebpackDevServer.
                     // When you `import` an asset, you get its (virtual) filename.

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
+const getLocalIdentPattern = require('./util/css-modules-local-ident');
 const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const applyOverrides = require('./util/apply-overrides');
@@ -104,6 +105,18 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
                     {
                         test: /\.css$/,
                         loader: require.resolve('null-loader')
+                    },
+                    {
+                        test: /\.pcss$/,
+                        use: [
+                            {
+                                loader: require.resolve('css-loader/locals'),
+                                options: {
+                                    modules: true,
+                                    localIdentName: getLocalIdentPattern({ isProduction: true })
+                                },
+                            }
+                        ],
                     },
                     // "file" loader makes sure those assets get served by WebpackDevServer.
                     // When you `import` an asset, you get its (virtual) filename.


### PR DESCRIPTION
### Добавлена поддержка css-модулей для *.pcss файлов

Если вдруг кто не знает что такое css-модули - [гугл в помощь](https://frontender.info/css-modules-part-1-need/).
Включил только для *.pcss файлов (многие редакторы по дефолту воспринимают это как postcss файлы). Для css включать не планируется, так как сломает существующие проекты, а делать это флагом не хочется.

