### PR TITLE
fix(config): change assets RegExp in proxy

### DIFF
--- a/configs/dev-server.js
+++ b/configs/dev-server.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const configs = require('./app-configs');
 const applyOverrides = require('./util/apply-overrides');
 
@@ -14,9 +15,13 @@ module.exports = applyOverrides('devServer', {
         '/**': {
             target: `http://localhost:${configs.serverPort}`,
             bypass: (req) => {
-                if (req.url.match(/^\/assets\//)) {
+                const assetsPath = path.resolve(`/${configs.publicPath}`);
+                const urlStart = req.url.substr(0, assetsPath.length);
+
+                if (urlStart === assetsPath) {
                     return req.url;
                 }
+
                 return false;
             }
         }

--- a/configs/dev-server.js
+++ b/configs/dev-server.js
@@ -14,7 +14,7 @@ module.exports = applyOverrides('devServer', {
         '/**': {
             target: `http://localhost:${configs.serverPort}`,
             bypass: (req) => {
-                if (req.url.match(/\./)) {
+                if (req.url.match(/^\/assets\//)) {
                     return req.url;
                 }
                 return false;

--- a/configs/dev-server.js
+++ b/configs/dev-server.js
@@ -15,10 +15,9 @@ module.exports = applyOverrides('devServer', {
         '/**': {
             target: `http://localhost:${configs.serverPort}`,
             bypass: (req) => {
-                const assetsPath = path.resolve(`/${configs.publicPath}`);
-                const urlStart = req.url.substr(0, assetsPath.length);
+                const assetsRoot = path.resolve(`/${configs.publicPath}`);
 
-                if (urlStart === assetsPath) {
+                if (req.url.startWith(assetsRoot)) {
                     return req.url;
                 }
 


### PR DESCRIPTION
Requests with dots in URL used to interpret as assets. It results to unexpected errors in some requests.