### PR TITLE
feat(*): allow override scripts settings by env

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ npm install arui-scripts --save-dev
 - `debug` - режим отладки, в котором не выполняются некоторые нежелательные операции и выводится больше сообщений об ошибках, по умолчанию `false`.
 - `useTscLoader` -  использовать ts-loader вместо babel-loader для обработки ts файлов. У babel-loader есть [ряд ограничений](https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/). По умолчанию `false`.
 
+В целях отладки все эти настройки можно переопределить не изменяя package.json
+Просто передайте необходимые настройки в environment переменной ARUI_SCRIPTS_CONFIG
+```
+ARUI_SCRIPTS_CONFIG="{\"serverPort\":3333}" yarn start
+```
+
 Так же, читаются настройки jest (см. [документацию](https://facebook.github.io/jest/docs/en/configuration.html))
 и `proxy` (см. [документацию](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#proxying-api-requests-in-development)).
 

--- a/configs/app-configs.js
+++ b/configs/app-configs.js
@@ -1,9 +1,21 @@
 const path = require('path');
 const fs = require('fs');
+const merge = require('lodash.merge');
 const CWD = process.cwd();
 
 const appPackage = JSON.parse(fs.readFileSync(path.join(CWD, 'package.json'), 'utf8'));
-const packageSettings = appPackage.aruiScripts || appPackage['arui-scripts'] || {};
+let packageSettings = appPackage.aruiScripts || appPackage['arui-scripts'] || {};
+
+if (process.env.ARUI_SCRIPTS_CONFIG) {
+    try {
+        console.warn('Используйте ARUI_SCRIPTS_CONFIG только для отладки');
+        envSettings = JSON.parse(process.env.ARUI_SCRIPTS_CONFIG);
+        packageSettings = merge(packageSettings, envSettings);
+    } catch (e) {
+        console.error(e);
+        throw Error('Not valid JSON passed. Correct it. For example: ARUI_SCRIPTS_CONFIG="{\"serverPort\":3333}"');
+    }
+}
 
 const buildPath = packageSettings.buildPath || '.build';
 const assetsPath = packageSettings.assetsPath || 'assets';


### PR DESCRIPTION
Иногда надо кое чего проверить, собрав приложение в докер или в архив,
Для этого мы изменяем package.json секция aruiScripts. Но потом забываешь вернуть все обратно
Предлагаю сделать возможность переопределять через env
```
ARUI_SCRIPTS_CONFIG="{\"serverPort\":3333}" yarn docker-build
```