### PR TITLE
chore(deps): bump typescript from 3.5.1 to 3.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,10 +100,11 @@
     "test": "npm run test-build && npm run test-test"
   },
   "devDependencies": {
+    "@types/node": "^8.9.1",
     "arui-presets-lint": "^2.0.0",
     "conventional-changelog-cli": "1.3.16",
     "husky": "^3.1.0",
-    "typescript": "3.5.1"
+    "typescript": "3.7.3"
   },
   "husky": {
     "hooks": {
@@ -117,7 +118,7 @@
     ]
   },
   "peerDependencies": {
-    "typescript": ">=3.5.1"
+    "typescript": ">=3.7.3"
   },
   "author": "Good guys from Alfa Laboratory",
   "maintainers": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.18.tgz#8d16634797d63c2af5bc647ce879f8de20b56469"
   integrity sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==
 
+"@types/node@^8.9.1":
+  version "8.10.59"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
+  integrity sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -9900,10 +9905,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
Подтянул версию TypeScript до актуальной.
Чтобы корректно проходились тесты с новой версией, добавил зависимость @types/node.