### PR TITLE
feat(jest): dynamic pass paths for jest from tsconfig for aliases

### DIFF
--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -2,6 +2,9 @@
     "compileOnSave": false,
     "compilerOptions": {
         "baseUrl": "./",
+        "paths": {
+            "Src/*": ["src/*"],
+        },
         "lib": [
             "dom",
             "es2015",

--- a/configs/jest/index.js
+++ b/configs/jest/index.js
@@ -1,5 +1,12 @@
-const configs = require('../app-configs');
+const fs = require('fs');
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
+const { parseConfigFileTextToJson } = require('typescript');
 const merge = require('lodash.merge');
+const configs = require('../app-configs');
+const tsConfigPath = configs.tsconfig;
+const tsConfig = fs.readFileSync(configs.tsconfig, 'utf8');
+const parseTsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfig);
+const parseTsConfigPaths = parseTsConfig.config.compilerOptions.paths || {};
 
 const defaultJestConfig = {
     testRegex: 'src/.*(test|spec|/__test__/|/__tests__/).*\\.(jsx?|tsx?)$',
@@ -16,7 +23,8 @@ const defaultJestConfig = {
     },
     moduleNameMapper: {
         // replace all css files with simple empty exports
-        '\\.css$': require.resolve('./css-mock')
+        '\\.css$': require.resolve('./css-mock'),
+        ...pathsToModuleNameMapper(parseTsConfigPaths, { prefix: '<rootDir>/' })
     },
     setupFiles: [
         require.resolve('./setup')

--- a/configs/jest/index.js
+++ b/configs/jest/index.js
@@ -4,9 +4,9 @@ const { parseConfigFileTextToJson } = require('typescript');
 const merge = require('lodash.merge');
 const configs = require('../app-configs');
 const tsConfigPath = configs.tsconfig;
-const tsConfig = fs.readFileSync(configs.tsconfig, 'utf8');
-const parseTsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfig);
-const parseTsConfigPaths = parseTsConfig.config.compilerOptions.paths || {};
+const tsConfigText = fs.readFileSync(configs.tsconfig, 'utf8');
+const tsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfigText);
+const tsConfigPaths = tsConfig.config.compilerOptions.paths || {};
 
 const defaultJestConfig = {
     testRegex: 'src/.*(test|spec|/__test__/|/__tests__/).*\\.(jsx?|tsx?)$',
@@ -24,7 +24,7 @@ const defaultJestConfig = {
     moduleNameMapper: {
         // replace all css files with simple empty exports
         '\\.css$': require.resolve('./css-mock'),
-        ...pathsToModuleNameMapper(parseTsConfigPaths, { prefix: '<rootDir>/' })
+        ...pathsToModuleNameMapper(tsConfigPaths, { prefix: '<rootDir>/' })
     },
     setupFiles: [
         require.resolve('./setup')


### PR DESCRIPTION
добавил динамический мапинг путей для jest из `tsconfig.ts` для случая использования алиасов https://github.com/alfa-laboratory/arui-scripts/issues/68