### PR TITLE
bugfix(jest-config): fix test files regexp

### DIFF
--- a/configs/jest/index.js
+++ b/configs/jest/index.js
@@ -9,7 +9,7 @@ const tsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfigText);
 const tsConfigPaths = tsConfig.config.compilerOptions.paths || {};
 
 const defaultJestConfig = {
-    testRegex: 'src/.*(test|spec|/__test__/|/__tests__/).*\\.(jsx?|tsx?)$',
+    testRegex: '^src.*((\/__test__\/|\/__tests__\/).*)|(test|spec|tests)\.(jsx?|tsx?)$',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     collectCoverageFrom: [
         'src/**/*.{js,jsx,ts,tsx}'


### PR DESCRIPTION
Текущий регексп триггерил на любой урл в котором хоть как-то есть test или spec
https://regex101.com/r/fOQqEY/1

Починил... теперь работает где нужно, а где не нужно не работает 
https://regex101.com/r/bhPbUS/2