### PR TITLE
Add @alfalab/icons and core-components to nodejs externals whitelist

### DIFF
--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -58,7 +58,16 @@ const config = {
                 .replace(/\\/g, '/'),
     },
     externals: [nodeExternals({
-        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/, /^@alfalab\/icons/]
+        whitelist: [
+            /^arui-feather/,
+            /^arui-ft-private/,
+            /^arui-private/,
+            /^alfaform-core-ui/,
+            /^newclick-components/,
+            /^#/,
+            /^@alfalab\/icons/,
+            /^@alfalab\/core-components/
+        ]
     })],
     resolve: {
         // This allows you to set a fallback for where Webpack should look for modules.

--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -58,7 +58,7 @@ const config = {
                 .replace(/\\/g, '/'),
     },
     externals: [nodeExternals({
-        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/]
+        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/, /^@alfalab\/icons/]
     })],
     resolve: {
         // This allows you to set a fallback for where Webpack should look for modules.

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -51,7 +51,16 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
                 .replace(/\\/g, '/'),
     },
     externals: [nodeExternals({
-        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/, /^@alfalab\/icons/,]
+        whitelist: [
+            /^arui-feather/,
+            /^arui-ft-private/,
+            /^arui-private/,
+            /^alfaform-core-ui/,
+            /^newclick-components/,
+            /^#/,
+            /^@alfalab\/icons/,
+            /^@alfalab\/core-components/
+        ]
     })],
     resolve: {
         // This allows you to set a fallback for where Webpack should look for modules.

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -51,7 +51,7 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
                 .replace(/\\/g, '/'),
     },
     externals: [nodeExternals({
-        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/]
+        whitelist: [/^arui-feather/, /^arui-ft-private/, /^arui-private/, /^alfaform-core-ui/, /^newclick-components/, /^#/, /^@alfalab\/icons/,]
     })],
     resolve: {
         // This allows you to set a fallback for where Webpack should look for modules.


### PR DESCRIPTION
Для корректной сборки и работы серверного скрипта добавил новые репозитории core-components и icons в nodejs externals whitelist