### PR TITLE
feat(*): css vars theming

### DIFF
--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -1,3 +1,5 @@
+const setupPostcssCustomProperties = require('./util/setup-postcss-custom-properties');
+
 /**
  * Функция для создания конфигурационного файла postcss
  * @param {String[]} plugins список плагинов
@@ -23,7 +25,7 @@ const postcssPlugins = [
     'postcss-for',
     'postcss-each',
     'postcss-custom-media',
-    'postcss-custom-properties',
+    '@alfalab/postcss-custom-properties',
     'postcss-strip-units',
     'postcss-calc',
     'postcss-color-function',
@@ -66,9 +68,7 @@ const postcssPluginsOptions = {
             '--desktop': 'screen and (min-width: 64em)'
         },
     },
-    'postcss-custom-properties': {
-        preserve: false,
-    },
+    '@alfalab/postcss-custom-properties': setupPostcssCustomProperties(),
 };
 
 module.exports = { postcssPlugins, postcssPluginsOptions, createPostcssConfig };

--- a/configs/util/setup-postcss-custom-properties.js
+++ b/configs/util/setup-postcss-custom-properties.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+const THEME_KEY = 'сomponentsTheme';
+
+/**
+ * Собирает конфиг для postcss-custom-properties.
+ * В случае наличия темы с css-переменными - импортирует ее.
+ * @returns {Object}
+ */
+function setupPostcssCustomProperties() {
+    const appPackage = require(path.join(process.cwd(), 'package.json'));
+
+    const config = {
+        preserve: false
+    };
+
+    if (THEME_KEY in appPackage) {
+        config.importFrom = appPackage[THEME_KEY];
+    }
+
+    return config;
+}
+
+module.exports = setupPostcssCustomProperties;

--- a/configs/util/setup-postcss-custom-properties.js
+++ b/configs/util/setup-postcss-custom-properties.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const { appPackage } = require('../app-configs');
 
 const THEME_KEY = 'сomponentsTheme';
 
@@ -8,8 +8,6 @@ const THEME_KEY = 'сomponentsTheme';
  * @returns {Object}
  */
 function setupPostcssCustomProperties() {
-    const appPackage = require(path.join(process.cwd(), 'package.json'));
-
     const config = {
         preserve: false
     };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "arui-scripts": "./bin/index.js"
   },
   "dependencies": {
+    "@alfalab/postcss-custom-properties": "^9.1.1",
     "@babel/core": "7.9.0",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-proposal-decorators": "7.8.3",
@@ -55,7 +56,6 @@
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^6.0.0",
-    "postcss-custom-properties": "^7.0.0",
     "postcss-discard-comments": "^2.0.4",
     "postcss-each": "^0.10.0",
     "postcss-for": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@alfalab/postcss-custom-properties@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@alfalab/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz#87bf16543d63d9f15c3a0bdf843bac71dfab3971"
+  integrity sha512-B4dL0AfRB2Syyf/1T0hKZPglObRo+sK3bltwaL08+NreXZm2E03MFpiNYG/3cEtnds3DScfDqBkG0VA5b2I9RQ==
+  dependencies:
+    postcss "^7.0.17"
+    postcss-values-parser "^3.0.5"
+
 "@babel/code-frame@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -2930,7 +2938,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -5499,6 +5507,11 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
+ip-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.1.0.tgz#5ad62f685a14edb421abebc2fff8db94df67b455"
+  integrity sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==
+
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -5890,6 +5903,13 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url-superb@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-3.0.0.tgz#b9a1da878a1ac73659047d1e6f4ef22c209d3e25"
+  integrity sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==
+  dependencies:
+    url-regex "^5.0.0"
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -8076,14 +8096,6 @@ postcss-custom-media@^6.0.0:
   dependencies:
     postcss "^6.0.1"
 
-postcss-custom-properties@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-7.0.0.tgz#24dc4fbe6d6ed550ea4fd3b11204660e9ffa3b33"
-  integrity sha512-dl/CNaM6z2RBa0vZZqsV6Hunj4HD6Spu7FcAkiVp5B2tgm6xReKKYzI7x7QNx3wTMBNj5v+ylfVcQGMW4xdkHw==
-  dependencies:
-    balanced-match "^1.0.0"
-    postcss "^6.0.18"
-
 postcss-discard-comments@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
@@ -8601,6 +8613,17 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
+postcss-values-parser@^3.0.5:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-3.1.1.tgz#487111a0446117d3463d2d429a380788f1365f69"
+  integrity sha512-p56/Cu9wb8+lck/iOTeuFeSHKEUH1bbWQ03T6N3jDkw+15pV65rMY5pK+OWhVpRn5TIrByS6UVpO3mSqvlhZYA==
+  dependencies:
+    color-name "^1.1.4"
+    is-number "^7.0.0"
+    is-url-superb "^3.0.0"
+    postcss "^7.0.5"
+    url-regex "^5.0.0"
+
 postcss@^5.0.0, postcss@^5.0.14, postcss@^5.0.21, postcss@^5.2.16:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -8611,7 +8634,7 @@ postcss@^5.0.0, postcss@^5.0.14, postcss@^5.0.21, postcss@^5.2.16:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.18, postcss@^6.0.22, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.22, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
@@ -8624,6 +8647,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.2
   version "7.0.25"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.25.tgz#dd2a2a753d50b13bed7a2009b4a18ac14d9db21e"
   integrity sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.17:
+  version "7.0.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
+  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -10462,6 +10494,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tlds@^1.203.0:
+  version "1.207.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"
+  integrity sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -10870,6 +10907,14 @@ url-parse@^1.1.8, url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
+  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
+  dependencies:
+    ip-regex "^4.1.0"
+    tlds "^1.203.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
### Мотивация

В `core-components` мы используем темизацию через css-переменные.
Предполагается, что компоненты можно будет стилизовать на проекте с помощью переопределения этих переменных.

#### Условный компонент из `core-components`:
```
:root {
    --border-radius: 4px;
}

.component {
    border-radius: var(--border-radius);
}
```

#### На проекте подключается файл с темой theme.css:
```
:root {
    --border-radius: 100px;
}
```

Все компоненты, которые используют эту переменную - получат **скругление в 100px** 👏

### Проблема

В плагине `postcss-custom-properties` есть возможность указать источник для импорта переменных с помощью опции `importFrom`.

Оказалось, что эта возможность работает **некорректно**.
Переменные из `importFrom` **НЕ** переопределяют уже существующие переменные.
В данном кейсе скругление так и осталось бы равным **4px**.

### Решение
- Было решено форкнуть последнюю версию `postcss-custom-properties` и сделать фикс, **который заключается в перестановке двух строчек местами** 🤷‍♂️
- Просмотрел проекты - никто не использует override данного плагина. Так что проблем не должно быть.
- Также я открыл [issue](https://github.com/postcss/postcss-custom-properties/issues/215), в надежде, что автор затянет этот фикс к себе.

### Изменения
1. Для упрощения темизации - добавлена возможность указать в `package.json` путь к теме, чтобы не создавать файл `arui-scripts.overrides.js`:
```
"сomponentsTheme": "./src/styles/theme.css"
```
2. В arui-scripts `postcss-custom-properties` заменен на форк: https://github.com/alfa-laboratory/postcss-custom-properties.

Мы потратили достаточно много времени на ресерч, но это решение оказалось самым подходящим. В любом случае, буду рад, если кто-то сможет предложить другое рабочее и удобное решение.
