### PR TITLE
fix(webpack-client): work with array-style webpack configs correctly

### DIFF
--- a/commands/build/client.js
+++ b/commands/build/client.js
@@ -23,8 +23,16 @@ build(config)
             console.log(chalk.green('Client compiled successfully.\n'));
         }
 
-        const sizes = calculateAssetsSizes(stats, config.output.path);
-        printAssetsSizes(sizes);
+        function printOutputSizes(webpackConfig) {
+            const sizes = calculateAssetsSizes(stats, webpackConfig.output.path);
+            printAssetsSizes(sizes);
+        }
+
+        if (Array.isArray(config)) {
+            config.forEach(printOutputSizes)
+        } else {
+            printOutputSizes(config);
+        }
     })
     .catch((err) => {
         console.log(chalk.red('Failed to compile client.\n'));


### PR DESCRIPTION
При использовании оверрайдов можно переопределить вебпак конфиги как массивы. Но при таком использовании даже при успешной сборке текущая реализация падает. Фиксим это