### PR TITLE
feat(client): add brotli support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/configs/app-configs.js
+++ b/configs/app-configs.js
@@ -49,7 +49,7 @@ module.exports = {
     name: appPackage.name,
     version: appPackage.version,
     dockerRegistry: '' || packageSettings.dockerRegistry,
-    baseDockerImage: packageSettings.baseDockerImage || 'heymdall/alpine-node-nginx:12.16.1',
+    baseDockerImage: packageSettings.baseDockerImage || 'heymdall/alpine-node-nginx:12.18.0',
 
     // general paths
     cwd: CWD,

--- a/configs/util/check-node-version.js
+++ b/configs/util/check-node-version.js
@@ -1,0 +1,7 @@
+function checkNodeVersion(majorVersion) {
+    const actualVersion = process.versions.node.split('.');
+
+    return parseInt(actualVersion[0], 10) >= majorVersion;
+}
+
+module.exports = checkNodeVersion;

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -291,6 +291,16 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
             threshold: 10240,
             minRatio: 0.8
         }),
+        new CompressionPlugin({
+            filename: '[file].br',
+            algorithm: 'brotliCompress',
+            test: /\.(js|css|html|svg)$/,
+            compressionOptions: {
+                level: 11,
+            },
+            threshold: 10240,
+            minRatio: 0.8,
+        }),
         configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
     ].filter(Boolean).concat(
         // Ignore prop-types packages in production mode

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -14,6 +14,7 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
+const checkNodeVersion = require('./util/check-node-version');
 
 const noopPath = require.resolve('./util/noop');
 
@@ -291,7 +292,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
             threshold: 10240,
             minRatio: 0.8
         }),
-        new CompressionPlugin({
+        checkNodeVersion(10) && new CompressionPlugin({
             filename: '[file].br',
             algorithm: 'brotliCompress',
             test: /\.(js|css|html|svg)$/,


### PR DESCRIPTION
Добавлена поддержка brotli. Будет работать если версия nodejs сборщика > 10. На меньших версиях будет статические архивы с brotli собираться не будут. 
Для современных браузеров будут отдаваться ассеты сжатые бротли, для старых - gzip.
Попробовал как работает на активном проекте, получилось примерно так:
```
            gzip  br
vendor.js   217   161
main.js     38.5  31.5
vendor.css  65.7  52.7
main.css    7.1   6.1
Total       328.3 251.3
```