### PR TITLE
chore(travis): remove travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-
-node_js:
-  - "8.9.3"
-  - "10.13.0"
-  - "11"


### PR DESCRIPTION
Проект теперь использует github actions. Смысла в поддержке двух ci нет