### PR TITLE
fix(webpack-server): source-map-support is now optional

### DIFF
--- a/configs/util/install-sourcemap-support.js
+++ b/configs/util/install-sourcemap-support.js
@@ -1,0 +1,5 @@
+try{
+    require('source-map-support').install();
+} catch (e) {
+    console.error('unable to install source map support. Please add `source-map-support` as a dependency.')
+}

--- a/configs/util/install-sourcemap-support.js
+++ b/configs/util/install-sourcemap-support.js
@@ -1,4 +1,4 @@
-try{
+try {
     require('source-map-support').install();
 } catch (e) {
     console.error('unable to install source map support. Please add `source-map-support` as a dependency.')

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -11,6 +11,7 @@ const babelConf = require('./babel-server');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
 const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-ignore'), 'utf8');
+const sourceMapSupportBanner = fs.readFileSync(require.resolve('./util/install-sourcemap-support'), 'utf8');
 
 // style files regexes
 const cssRegex = /\.css$/;
@@ -180,7 +181,7 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
             entryOnly: false
         }),
         new webpack.BannerPlugin({
-            banner: 'require("source-map-support").install();',
+            banner: sourceMapSupportBanner,
             raw: true,
             entryOnly: false
         }),


### PR DESCRIPTION
Fixes #43 
Сделал пакет source-map-support опциональной зависимостью. Теперь серверная часть будет работать даже когда пакет не установлен