### PR TITLE
Минорное изменение для ts-jest конфига

### DIFF
--- a/configs/jest/index.js
+++ b/configs/jest/index.js
@@ -34,7 +34,8 @@ const defaultJestConfig = {
     ],
     globals: {
         'ts-jest': {
-            tsConfig: configs.tsconfig
+            tsConfig: configs.tsconfig,
+            babelConfig: require('../babel-client')
         }
     }
 };


### PR DESCRIPTION
В последних версиях arui-scripts в tsconfig используется target: esnext, что приводит к ошибкам (если тест файлы имеют расширение ts) в тестах при условии, что в них используются нововведения из ES2020, в частности nullish-coalescing-operator и optional-chaining. Вопрос можно решить донастройкой ts-jest в package.json отдельного взятого проекта, либо пробросив в defaultJestConfig в ts-jest babel конфиг, который и так используется в  arui-scripts, таким образом все будет заводится "из коробки" без дополнительных конфигураций в package.json проекта.
