### PR TITLE
feat(supporting-browsers): add supporting-browsers to overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,5 +438,6 @@ module.exports = {
 - `webpack.client.prod` - конфигурация для клиентского webpack в prod режиме. Ключи: `webpack`, `webpackClient`, `webpackProd`, `webpackClientProd`.
 - `webpack.server.dev` - конфигурация для серверного webpack в dev режиме. Ключи: `webpack`, `webpackServer`, `webpackDev`, `webpackServerDev`.
 - `webpack.server.prod` - конфигурация для серверного webpack в prod режиме. Ключи: `webpack`, `webpackServer`, `webpackProd`, `webpackServerProd`.
+- `supporting-browsers` - список поддерживаемых браузеров в формате [browserslist](https://github.com/browserslist/browserslist). Ключи: `browsers`, `supportingBrowsers`
 
 Для некоторых конфигураций определены несколько ключей, они будут применяться в том порядке, в котором они приведены в этом файле.

--- a/configs/supporting-browsers.js
+++ b/configs/supporting-browsers.js
@@ -1,6 +1,8 @@
-module.exports = [
+const applyOverrides = require('./util/apply-overrides');
+
+module.exports = applyOverrides(['browsers', 'supportingBrowsers'], [
     'last 2 versions',
     'ie >= 10',
     'Android >= 4',
     'iOS >= 9'
-];
+]);


### PR DESCRIPTION
Нужно иметь возможность переопределять список поддерживаемых браузеров для проекта. Сейчас это можно сделать в `arui-scripts.overrides.js` только так:
```javascript
babelClient: (config) => {
    config.presets[0][1].targets.browsers = ['my', 'browsers'];
    return config;
}
```

Предлагаю упростить это до вот такого:
```javascript
supportingBrowsers: () => ['my', 'browsers'];
```