### PR TITLE
feat(webpack): add support for multiple entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ ARUI_SCRIPTS_CONFIG="{\"serverPort\":3333}" yarn start
 Так же, читаются настройки jest (см. [документацию](https://facebook.github.io/jest/docs/en/configuration.html))
 и `proxy` (см. [документацию](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#proxying-api-requests-in-development)).
 
+Несколько entry point
+---
+Ключи `serverEntry` и `clientEntry` принимают не только строки, но и любые возможные в [webpack варианты](https://webpack.js.org/concepts/entry-points/).
+Например, package.json:
+```json
+{
+    "aruiScripts": {
+        "clientEntry": { "mobile": "src/mobile/", "desktop": "src/desktop/" },
+        "serverEntry": ["src/server-prepare", "src/server"]
+    }
+}
+```
+
+Ко всем клиентским entryPoint так же будут добавлены `clientPolyfillsEntry` (если задан)
+и, в dev режиме, необходимые для hot-module-reload файлы.
+
 Переопределение настроек компиляторов
 ---
 

--- a/commands/util/check-required-files.js
+++ b/commands/util/check-required-files.js
@@ -47,6 +47,7 @@ function checkFileWithExtensions(filePath, extensions) {
 
 function checkRequiredFiles() {
     const unavailableFilePaths = files
+        .filter(Boolean)
         .reduce((result, filePath) => {
             if (filePath && !checkFileWithExtensions(filePath, extensions)) {
                 result.push(filePath);

--- a/commands/util/check-required-files.js
+++ b/commands/util/check-required-files.js
@@ -6,9 +6,22 @@ const configs = require('../../configs/app-configs');
 
 const extensions = ['ts', 'tsx', 'js', 'jsx'];
 
+function entryPointToArray(entryPoint) {
+    if (typeof entryPoint === 'string') {
+        return [entryPoint];
+    }
+    if (Array.isArray(entryPoint)) {
+        return entryPoint;
+    }
+    return Object.keys(entryPoint).reduce((result, name) => {
+        const entry = entryPointToArray(entryPoint[name]);
+        return [...result, ...entry];
+    }, []);
+}
+
 const files = [
-    configs.serverEntry,
-    configs.clientEntry,
+    ...entryPointToArray(configs.serverEntry),
+    ...entryPointToArray(configs.clientEntry),
     configs.clientPolyfillsEntry
 ];
 

--- a/configs/util/get-entry-point.js
+++ b/configs/util/get-entry-point.js
@@ -1,0 +1,24 @@
+/**
+ * @param {string|string[]|object} entryPoint Строка, массив строк или объект с энтрипоинтами
+ * @param {Function} getSingleEntryPoint Функция, возвращающая конфигурацию для одного entryPoint
+ * @returns {*}
+ */
+function getEntryPoint(entryPoint, getSingleEntryPoint) {
+    if (typeof entryPoint === 'string') {
+        return getSingleEntryPoint([entryPoint]);
+    }
+    if (Array.isArray(entryPoint)) {
+        return getSingleEntryPoint(entryPoint);
+    }
+    // client entry also can be an object, so we must add hot loader to each entry point
+    return Object.keys(entryPoint).reduce((result, entryPointName) => {
+        const entry = getEntryPoint(entryPoint[entryPointName], getSingleEntryPoint);
+
+        return {
+            ...result,
+            [entryPointName]: entry
+        };
+    }, {});
+}
+
+module.exports = getEntryPoint;

--- a/configs/util/get-entry.js
+++ b/configs/util/get-entry.js
@@ -1,18 +1,18 @@
 /**
  * @param {string|string[]|object} entryPoint Строка, массив строк или объект с энтрипоинтами
- * @param {Function} getSingleEntryPoint Функция, возвращающая конфигурацию для одного entryPoint
+ * @param {Function} getSingleEntry Функция, возвращающая конфигурацию для одного entryPoint
  * @returns {*}
  */
-function getEntryPoint(entryPoint, getSingleEntryPoint) {
+function getEntry(entryPoint, getSingleEntry) {
     if (typeof entryPoint === 'string') {
-        return getSingleEntryPoint([entryPoint]);
+        return getSingleEntry([entryPoint]);
     }
     if (Array.isArray(entryPoint)) {
-        return getSingleEntryPoint(entryPoint);
+        return getSingleEntry(entryPoint);
     }
     // client entry also can be an object, so we must add hot loader to each entry point
     return Object.keys(entryPoint).reduce((result, entryPointName) => {
-        const entry = getEntryPoint(entryPoint[entryPointName], getSingleEntryPoint);
+        const entry = getEntry(entryPoint[entryPointName], getSingleEntry);
 
         return {
             ...result,
@@ -21,4 +21,4 @@ function getEntryPoint(entryPoint, getSingleEntryPoint) {
     }, {});
 }
 
-module.exports = getEntryPoint;
+module.exports = getEntry;

--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -4,17 +4,32 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
+
 const configs = require('./app-configs');
 const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
+const getEntryPoint = require('./util/get-entry-point');
 // style files regexes
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
+
+function getSingleEntryPoint(clientEntry) {
+    return [
+        configs.clientPolyfillsEntry,
+        require.resolve('react-hot-loader/patch'),
+        `${require.resolve('webpack-dev-server/client')}?/`,
+        require.resolve('webpack/hot/dev-server'),
+        // Finally, this is your app's code:
+        ...clientEntry,
+        // We include the app code last so that if there is a runtime error during
+        // initialization, it doesn't blow up the WebpackDevServer client, and
+        // changing JS code would still trigger a refresh.
+    ].filter(Boolean);
+}
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -25,17 +40,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
     devtool: 'cheap-module-source-map',
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
-    entry: [
-        configs.clientPolyfillsEntry,
-        require.resolve('react-hot-loader/patch'),
-        `${require.resolve('webpack-dev-server/client')}?/`,
-        require.resolve('webpack/hot/dev-server'),
-        // Finally, this is your app's code:
-        configs.clientEntry,
-        // We include the app code last so that if there is a runtime error during
-        // initialization, it doesn't blow up the WebpackDevServer client, and
-        // changing JS code would still trigger a refresh.
-    ].filter(Boolean),
+    entry: getEntryPoint(configs.clientEntry, getSingleEntryPoint),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.

--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -12,12 +12,12 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
-const getEntryPoint = require('./util/get-entry-point');
+const getEntry = require('./util/get-entry');
 // style files regexes
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
-function getSingleEntryPoint(clientEntry) {
+function getSingleEntry(clientEntry) {
     return [
         configs.clientPolyfillsEntry,
         require.resolve('react-hot-loader/patch'),
@@ -40,7 +40,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
     devtool: 'cheap-module-source-map',
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
-    entry: getEntryPoint(configs.clientEntry, getSingleEntryPoint),
+    entry: getEntry(configs.clientEntry, getSingleEntry),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -15,7 +15,7 @@ const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
 const checkNodeVersion = require('./util/check-node-version');
-const getEntryPoint = require('./util/get-entry-point');
+const getEntry = require('./util/get-entry');
 
 const noopPath = require.resolve('./util/noop');
 
@@ -23,7 +23,7 @@ const noopPath = require.resolve('./util/noop');
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
-function getSingleEntryPoint(entryPoint) {
+function getSingleEntry(entryPoint) {
     return [configs.clientPolyfillsEntry, ...entryPoint].filter(Boolean);
 }
 
@@ -33,7 +33,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'web
     // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
     devtool: 'cheap-module-source-map',
     // In production, we only want to load the polyfills and the app code.
-    entry: getEntryPoint(configs.clientEntry, getSingleEntryPoint),
+    entry: getEntry(configs.clientEntry, getSingleEntry),
     bail: true,
     context: configs.cwd,
     output: {

--- a/configs/webpack.client.prod.js
+++ b/configs/webpack.client.prod.js
@@ -15,6 +15,7 @@ const babelConf = require('./babel-client');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
 const checkNodeVersion = require('./util/check-node-version');
+const getEntryPoint = require('./util/get-entry-point');
 
 const noopPath = require.resolve('./util/noop');
 
@@ -22,13 +23,17 @@ const noopPath = require.resolve('./util/noop');
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
+function getSingleEntryPoint(entryPoint) {
+    return [configs.clientPolyfillsEntry, ...entryPoint].filter(Boolean);
+}
+
 // This is the production configuration.
 module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackProd', 'webpackClientProd'], {
     mode: 'production',
     // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
     devtool: 'cheap-module-source-map',
     // In production, we only want to load the polyfills and the app code.
-    entry: [configs.clientPolyfillsEntry, configs.clientEntry].filter(Boolean),
+    entry: getEntryPoint(configs.clientEntry, getSingleEntryPoint),
     bail: true,
     context: configs.cwd,
     output: {

--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -15,7 +15,7 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
-const getEntryPoint = require('./util/get-entry-point');
+const getEntry = require('./util/get-entry');
 
 const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-ignore'), 'utf8');
 
@@ -23,7 +23,7 @@ const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-i
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
-function getSingleEntryPoint(entryPoint) {
+function getSingleEntry(entryPoint) {
     return [...entryPoint];
 }
 
@@ -39,7 +39,7 @@ const config = {
         __filename: true,
         __dirname: true
     },
-    entry: getEntryPoint(configs.serverEntry, getSingleEntryPoint),
+    entry: getEntry(configs.serverEntry, getSingleEntry),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.

--- a/configs/webpack.server.dev.js
+++ b/configs/webpack.server.dev.js
@@ -15,11 +15,17 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
+const getEntryPoint = require('./util/get-entry-point');
+
 const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-ignore'), 'utf8');
 
 // style files regexes
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
+
+function getSingleEntryPoint(entryPoint) {
+    return [...entryPoint];
+}
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -33,16 +39,7 @@ const config = {
         __filename: true,
         __dirname: true
     },
-    // These are the "entry points" to our application.
-    // This means they will be the "root" imports that are included in JS bundle.
-    // The first two entry points enable "hot" CSS and auto-refreshes for JS.
-    entry: [
-        // Finally, this is your app's code:
-        configs.serverEntry,
-        // We include the app code last so that if there is a runtime error during
-        // initialization, it doesn't blow up the WebpackDevServer client, and
-        // changing JS code would still trigger a refresh.
-    ],
+    entry: getEntryPoint(configs.serverEntry, getSingleEntryPoint),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -10,7 +10,7 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
-const getEntryPoint = require('./util/get-entry-point');
+const getEntry = require('./util/get-entry');
 const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-ignore'), 'utf8');
 const sourceMapSupportBanner = fs.readFileSync(require.resolve('./util/install-sourcemap-support'), 'utf8');
 
@@ -18,7 +18,7 @@ const sourceMapSupportBanner = fs.readFileSync(require.resolve('./util/install-s
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
-function getSingleEntryPoint(entryPoint) {
+function getSingleEntry(entryPoint) {
     return [...entryPoint];
 }
 
@@ -36,7 +36,7 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
         __filename: true,
         __dirname: true
     },
-    entry: getEntryPoint(configs.serverEntry, getSingleEntryPoint),
+    entry: getEntry(configs.serverEntry, getSingleEntry),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.

--- a/configs/webpack.server.prod.js
+++ b/configs/webpack.server.prod.js
@@ -10,12 +10,17 @@ const configs = require('./app-configs');
 const babelConf = require('./babel-server');
 const postcssConf = require('./postcss');
 const applyOverrides = require('./util/apply-overrides');
+const getEntryPoint = require('./util/get-entry-point');
 const assetsIgnoreBanner = fs.readFileSync(require.resolve('./util/node-assets-ignore'), 'utf8');
 const sourceMapSupportBanner = fs.readFileSync(require.resolve('./util/install-sourcemap-support'), 'utf8');
 
 // style files regexes
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
+
+function getSingleEntryPoint(entryPoint) {
+    return [...entryPoint];
+}
 
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
@@ -31,12 +36,7 @@ module.exports = applyOverrides(['webpack', 'webpackServer', 'webpackProd', 'web
         __filename: true,
         __dirname: true
     },
-    // These are the "entry points" to our application.
-    // This means they will be the "root" imports that are included in JS bundle.
-    entry: [
-        // Finally, this is your app's code:
-        configs.serverEntry,
-    ],
+    entry: getEntryPoint(configs.serverEntry, getSingleEntryPoint),
     context: configs.cwd,
     output: {
         // Add /* filename */ comments to generated require()s in the output.


### PR DESCRIPTION
Добавлена поддержка любых возможных конфигураций entryPoint, как серверной, так и клиентской.
Теперь через настройки в package.json можно передавать строку, массив, или объект с entryPoint