### PR TITLE
feat(postcss-config): add postcss-color-mod-function

### DIFF
--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -29,6 +29,7 @@ const postcssPlugins = [
     'postcss-strip-units',
     'postcss-calc',
     'postcss-color-function',
+    'postcss-color-mod-function',
     'postcss-nested',
     'autoprefixer',
     'postcss-inherit',
@@ -70,7 +71,10 @@ const postcssPluginsOptions = {
     },
     '@alfalab/postcss-custom-properties': {
         preserve: false,
-        importFrom: componentsTheme
+        importFrom: componentsTheme,
+    },
+    'postcss-color-mod-function': {
+        unresolved: 'warn',
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",
+    "postcss-color-mod-function": "^3.0.3",
     "postcss-custom-media": "^6.0.0",
     "postcss-discard-comments": "^2.0.4",
     "postcss-each": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,6 +1089,11 @@
   dependencies:
     find-up "^4.0.0"
 
+"@csstools/convert-colors@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
+  integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+
 "@hot-loader/react-dom@16.11.0":
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.11.0.tgz#c0b483923b289db5431516f56ee2a69448ebf9bd"
@@ -7778,6 +7783,15 @@ postcss-color-function@^4.0.1:
     postcss-message-helpers "^2.0.0"
     postcss-value-parser "^3.3.1"
 
+postcss-color-mod-function@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz#816ba145ac11cc3cb6baa905a75a49f903e4d31d"
+  integrity sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==
+  dependencies:
+    "@csstools/convert-colors" "^1.4.0"
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
 postcss-colormin@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-4.0.3.tgz#ae060bce93ed794ac71264f08132d550956bd381"
@@ -8316,6 +8330,15 @@ postcss-value-parser@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz#651ff4593aa9eda8d5d0d66593a2417aeaeb325d"
   integrity sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==
+
+postcss-values-parser@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
+  integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
 
 postcss-values-parser@^3.0.5:
   version "3.1.1"


### PR DESCRIPTION
На обсуждении было решено использовать `color-mod` для модификации цветов.
Хоть это и deprecated, но плагины под новую спеку еще сырые. 

`postcss-color-function` - не подходит под требования, т.к. у него есть проблемы с css-переменными и не поддерживаются некоторые функции, типа blenda. 

