### PR TITLE
feat(webpack): replace style tags with optimized css bundle in dev

### DIFF
--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
@@ -152,7 +154,12 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
                         test: cssRegex,
                         exclude: cssModuleRegex,
                         use: [
-                            require.resolve('style-loader'),
+                            {
+                                loader: MiniCssExtractPlugin.loader,
+                                options: {
+                                    hmr: true,
+                                },
+                            },
                             {
                                 loader: require.resolve('css-loader'),
                                 options: {
@@ -173,7 +180,12 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
                     {
                         test: cssModuleRegex,
                         use: [
-                            require.resolve('style-loader'),
+                            {
+                                loader: MiniCssExtractPlugin.loader,
+                                options: {
+                                    hmr: true,
+                                },
+                            },
                             {
                                 loader: require.resolve('css-loader'),
                                 options: {
@@ -238,6 +250,22 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
         //     }
         // ])
         configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
+        new MiniCssExtractPlugin(),
+        new OptimizeCssAssetsPlugin({
+            cssProcessorOptions: {
+                map: {
+                    inline: false,
+                    annotation: true
+                },
+            },
+            cssProcessorPluginOptions: {
+                preset: () => ({
+                    plugins: [
+                        require('postcss-discard-duplicates')
+                    ]
+                })
+            },
+        }),
     ].filter(Boolean),
     // Some libraries import Node modules but don't use them in the browser.
     // Tell Webpack to provide empty mocks for them so importing them works.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "23.6.0",
     "jest-snapshot-serializer-class-name-to-string": "1.0.0",
     "lodash.merge": "4.6.2",
-    "mini-css-extract-plugin": "^0.11.0",
+    "mini-css-extract-plugin": "0.11.0",
     "null-loader": "0.1.1",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "postcss-calc": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "23.6.0",
     "jest-snapshot-serializer-class-name-to-string": "1.0.0",
     "lodash.merge": "4.6.2",
-    "mini-css-extract-plugin": "0.4.4",
+    "mini-css-extract-plugin": "^0.11.0",
     "null-loader": "0.1.1",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "postcss-calc": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5584,7 +5584,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -6847,12 +6847,13 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-mini-css-extract-plugin@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.4.tgz#c10410a004951bd3cedac1da69053940fccb625d"
-  integrity sha512-o+Jm+ocb0asEngdM6FsZWtZsRzA8koFUudIDwYUfl94M3PejPHG7Vopw5hN9V8WsMkSFpm3tZP3Fesz89EyrfQ==
+mini-css-extract-plugin@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.0.tgz#3918953075109d4ca204bf1e8a393a78d3cc821f"
+  integrity sha512-dVWGuWJlQw2lZxsxBI3hOsoxg1k3DruLR0foHQLSkQMfk+qLJbv9dUk8fjmjWQKN9ef2n54ehA2FjClAsQhrWQ==
   dependencies:
     loader-utils "^1.1.0"
+    normalize-url "1.9.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
@@ -7142,6 +7143,16 @@ normalize-selector@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
   integrity sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=
+
+normalize-url@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
+  integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
+  dependencies:
+    object-assign "^4.0.1"
+    prepend-http "^1.0.0"
+    query-string "^4.1.0"
+    sort-keys "^1.0.0"
 
 normalize-url@^3.0.0:
   version "3.3.0"
@@ -8361,6 +8372,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prepend-http@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -8509,6 +8525,14 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+query-string@^4.1.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -9546,6 +9570,13 @@ sockjs@0.3.19:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
 
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -9775,6 +9806,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6847,7 +6847,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-mini-css-extract-plugin@^0.11.0:
+mini-css-extract-plugin@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.0.tgz#3918953075109d4ca204bf1e8a393a78d3cc821f"
   integrity sha512-dVWGuWJlQw2lZxsxBI3hOsoxg1k3DruLR0foHQLSkQMfk+qLJbv9dUk8fjmjWQKN9ef2n54ehA2FjClAsQhrWQ==


### PR DESCRIPTION
## Проблема

postcss обрабатывает каждый файл отдельно, поэтому импорты переменных в каждом файле приводят к их дублированию и ~пиздецу~.

Одно из решений - сделать один бандл и оптимизировать его.

## Изменения

Для дев режима:
1. Заменил style-loader на MiniCssExtractPlugin, который объединяет стили в один файл.
2. OptimizeCSSAssetsPlugin прогоняет полученный бандл через cssnano, который удаляет дубли. Из cssnano оставил только discardDuplicates

- [x] hmr
- [x] sourcemaps

Сорсмапы работают, но отображается не очень красивый путь:

<img src="https://user-images.githubusercontent.com/9968618/91813214-04719680-ec3b-11ea-93a4-7cf9d0212e2c.png" width="320" />

Решение [тут](https://github.com/alfa-laboratory/arui-scripts/commits/refactor/replace-style-loader), но для этого нужно обновить css-loader, который требует уже 10ую ноду. 

Думаю кривой путь - не проблема, т.к. сейчас вообще просто пишется <style> и не отображаются строки
