### PR TITLE
fix(webpack): fix react hooks and yarn link error

### DIFF
--- a/configs/webpack.client.dev.js
+++ b/configs/webpack.client.dev.js
@@ -60,6 +60,7 @@ module.exports = applyOverrides(['webpack', 'webpackClient', 'webpackDev', 'webp
     resolve: {
         alias: {
             'react-dom': '@hot-loader/react-dom',
+            react: require.resolve('react')
         },
         // This allows you to set a fallback for where Webpack should look for modules.
         // We placed these paths second because we want `node_modules` to "win"


### PR DESCRIPTION
Столкнулся с проблемой: хочу протестировать компонент, написанный на хуках, в стабе, использующем `arui-scripts`. 
Для этого через `yarn link` слинковал его.
Получил ошибку: `hooks can only be called inside the body of a function component...`