### PR TITLE
fix(webpack-server): add date-fns to externals

### DIFF
--- a/packages/arui-scripts/src/configs/webpack.server.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.dev.ts
@@ -66,7 +66,8 @@ const config: webpack.Configuration = {
             /^newclick-composite-components/,
             /^#/,
             /^@alfalab\/icons/,
-            /^@alfalab\/core-components/
+            /^@alfalab\/core-components/,
+            /^date-fns/,
         ],
         modulesFromFile: true,
     })],

--- a/packages/arui-scripts/src/configs/webpack.server.prod.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.prod.ts
@@ -63,7 +63,8 @@ const config = applyOverrides<webpack.Configuration>(['webpack', 'webpackServer'
             /^newclick-composite-components/,
             /^#/,
             /^@alfalab\/icons/,
-            /^@alfalab\/core-components/
+            /^@alfalab\/core-components/,
+            /^date-fns/,
         ],
         // we cannot determine node_modules location before arui-scripts installation, so just load
         // dependencies list from package.json


### PR DESCRIPTION
Исправляем осточертевший баг с конфликтом версии date-fns в проекте и в arui-feather. Теперь оба эти пакеты будут externals, так что резолвинг будет работать корректно