### PR TITLE
fix(webpack-dev): add public path, so images loads correctly in dev mode

### DIFF
--- a/packages/arui-scripts/src/configs/webpack.client.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.dev.ts
@@ -165,6 +165,7 @@ const webpackClientDev = applyOverrides<webpack.Configuration>(['webpack', 'webp
                                 loader: MiniCssExtractPlugin.loader,
                                 options: {
                                     hmr: true,
+                                    publicPath: './',
                                 },
                             },
                             {
@@ -191,6 +192,7 @@ const webpackClientDev = applyOverrides<webpack.Configuration>(['webpack', 'webp
                                 loader: MiniCssExtractPlugin.loader,
                                 options: {
                                     hmr: true,
+                                    publicPath: './',
                                 },
                             },
                             {


### PR DESCRIPTION
Без этого в дев режиме не корректно грузятся картинки которые не попадают под размеры url-loader