### PR TITLE
fix(nginx): always use only ipv4 host

### DIFF
--- a/packages/arui-scripts/src/templates/nginx.conf.template.ts
+++ b/packages/arui-scripts/src/templates/nginx.conf.template.ts
@@ -6,7 +6,7 @@ server {
     listen ${configs.clientServerPort};
 
     location / {
-        proxy_pass http://localhost:${configs.serverPort};
+        proxy_pass http://127.0.0.1:${configs.serverPort};
     }
 
     location /${configs.publicPath} {


### PR DESCRIPTION
Делаем так, чтоб nginx всегда использовал только ipv4 хост для поиска ноды. В некоторых случаях localhost внутри контейнера может разрезолвится в ipv6 адрес, nodejs обычно на ipv6 у нас не слушает, и в итоге мы можем получить 503 ошибку