### PR TITLE
fix(dev-server): fix wrong path and url comparison on windows

### DIFF
--- a/packages/arui-scripts/src/configs/dev-server.ts
+++ b/packages/arui-scripts/src/configs/dev-server.ts
@@ -17,7 +17,7 @@ const devServerConfig = applyOverrides<Configuration>('devServer', {
         '/**': {
             target: `http://localhost:${configs.serverPort}`,
             bypass: (req: http.IncomingMessage) => {
-                const assetsRoot = path.resolve(`/${configs.publicPath}`);
+                const assetsRoot = path.normalize(`/${configs.publicPath}`).replace(/\\/g, '/');
 
                 if (req?.url?.startsWith(assetsRoot)) {
                     return req.url;


### PR DESCRIPTION
`path.resolve` возвращает абсолютный путь, на Windows к нему добавляется имя диска в начале, что приводит к некорректному сравнению `req.url` и `assetsRoot`. Заменил `path.resolve` на `path.normalize`, т.к. слеш в начале пути уже указывает, что путь абсолютный и `path.resolve` просто нормализует путь. `path.normalize` не пытается сделать путь абсолютным, и не добавляет имя диска к пути на Windows.