### PR TITLE
fix(*): fix folder error

### DIFF
--- a/packages/arui-scripts/src/templates/dockerfile.template.ts
+++ b/packages/arui-scripts/src/templates/dockerfile.template.ts
@@ -2,6 +2,7 @@ import configs from '../configs/app-configs';
 
 const nginxNonRootPart = configs.runFromNonRootUser ?
   `RUN chown -R nginx:nginx /src && chmod -R 755 /src && \\
+       mkdir -p /var/lib/nginx && \\
        chown -R nginx:nginx /var/lib/nginx && \\
        chown -R nginx:nginx /var/log/nginx && \\
        chown -R nginx:nginx /etc/nginx/conf.d


### PR DESCRIPTION
Когда собираем образ с флагом  "runFromNonRootUser": true - то получаем ошибку: chown: /var/lib/nginx: No such file or directory

Это ошибка воспроизводиться как локально так и в бамбу.

Скрин локальной сборки:
![image](https://user-images.githubusercontent.com/14177501/104631637-955a8300-56ad-11eb-8cdc-d1a0e29d6e78.png)

Скрин cборки bamboo:
![image](https://user-images.githubusercontent.com/14177501/104631790-ccc92f80-56ad-11eb-8819-517dc057740a.png)

--

После добавления mkdir -p (этот флаг означает, что если нет такой папки то нужно создавать) все работает корректно. 
