### PR TITLE
fix(nodejs): allow to use more memory on constrained environments

### DIFF
--- a/packages/arui-scripts/src/templates/start.template.ts
+++ b/packages/arui-scripts/src/templates/start.template.ts
@@ -5,11 +5,17 @@ const startTemplate = `#!/bin/sh
 # Move nginx config
 mv ./nginx.conf /etc/nginx/conf.d/default.conf
 
+# Достаем лимит памяти из cgroup, это то, как его докер задает.  https://shuheikagawa.com/blog/2017/05/27/memory-usage/
+max_total_memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+# Самой nodejs мы не можем отдать совсем всю память, операционная система+nginx все же требуют какого то количества.
+# Поэтому мы вычитаем 100мб на нужды ос
+node_memory_limit="$(($max_total_memory / 1024 / 1024 - 100))"
+
 # Start the nginx process in background
 nginx &
 
 # Start nodejs process
-node ./${configs.buildPath}/${configs.serverOutput}
+node --max-old-space-size="$node_memory_limit" ./${configs.buildPath}/${configs.serverOutput}
 `;
 
 export default startTemplate;


### PR DESCRIPTION
Оказывается, в 12 ноде поменялось то, сколько памяти по дефолту выдкеляется под хип. Раньше дефолт был около 1400мб (для x64), что было логично для браузера, но странно для сервисов на nodejs. И они его поменяли, теперь вроде стало логично, nodejs стал передавать в v8 то, сколько памяти таки можно брать, причем даже с учетом лимитов от докера. Очень круто и логично. 
Но! У v8 есть еще и свой код, который в зависимости от максимально доступной памяти, ограничивает то, сколько можно выделить под хип.
Вот тут есть комент с подробным описанием, кратко - если у вас максимальный объем памяти <= 512мб - вам будет выделено 256мб. 
Поскольку большая часть наших фронтов запускают nodejs в докер контейнерах, с ограничением по памяти в 512мб нода у большинства из нас оказывается загнаной в весьма узкие рамки, что может приводить к ее смерти из-за недостатка памяти. Причем остальная память остается тупо не используемой, nginx даже в самых нагруженных проектах потребляет от силы 50мб, alpine же и вовсе требует что-то типа 5мб. 