### PR TITLE
feat(configs): add css-custom-properties polyfill when keepCssVars enabled

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -3036,6 +3036,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "npm:4.1.1"
       ],
       [
+        "ie11-custom-properties",
+        "npm:4.1.0"
+      ],
+      [
         "ieee754",
         "npm:1.1.13"
       ],
@@ -10958,6 +10962,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fork-ts-checker-webpack-plugin", "npm:5.2.0"],
             ["fs-extra", "npm:6.0.1"],
             ["gzip-size", "npm:5.1.1"],
+            ["ie11-custom-properties", "npm:4.1.0"],
             ["jest", "npm:25.5.4"],
             ["jest-snapshot-serializer-class-name-to-string", "npm:1.0.0"],
             ["lodash.merge", "npm:4.6.2"],
@@ -11093,6 +11098,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fork-ts-checker-webpack-plugin", "npm:5.2.0"],
             ["fs-extra", "npm:6.0.1"],
             ["gzip-size", "npm:5.1.1"],
+            ["ie11-custom-properties", "npm:4.1.0"],
             ["jest", "npm:25.5.4"],
             ["jest-snapshot-serializer-class-name-to-string", "npm:1.0.0"],
             ["lodash.merge", "npm:4.6.2"],
@@ -17482,6 +17488,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["icss-utils", "npm:4.1.1"],
             ["postcss", "npm:7.0.32"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["ie11-custom-properties", [
+        ["npm:4.1.0", {
+          "packageLocation": "./.yarn/cache/ie11-custom-properties-npm-4.1.0-503be21d67-66a934b402.zip/node_modules/ie11-custom-properties/",
+          "packageDependencies": [
+            ["ie11-custom-properties", "npm:4.1.0"]
           ],
           "linkType": "HARD",
         }]

--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -51,6 +51,7 @@
         "fork-ts-checker-webpack-plugin": "5.2.0",
         "fs-extra": "6.0.1",
         "gzip-size": "5.1.1",
+        "ie11-custom-properties": "^4.1.0",
         "jest": "25.5.4",
         "jest-snapshot-serializer-class-name-to-string": "1.0.0",
         "lodash.merge": "4.6.2",

--- a/packages/arui-scripts/src/configs/app-configs.ts
+++ b/packages/arui-scripts/src/configs/app-configs.ts
@@ -99,7 +99,7 @@ let config: AppConfigs = {
     serverOutput: 'server.js',
 
     // client compilation configs
-    clientPolyfillsEntry: aruiPolyfills,
+    clientPolyfillsEntry: require.resolve('./polyfills/arui-feather'),
     clientEntry: path.resolve(absoluteSrcPath, 'index'),
     keepPropTypes: false,
 
@@ -179,5 +179,9 @@ if (process.env.ARUI_SCRIPTS_CONFIG) {
 config.publicPath = `${config.assetsPath}/`;
 config.serverOutputPath = path.resolve(CWD, config.buildPath);
 config.clientOutputPath = path.resolve(CWD, config.buildPath, config.assetsPath);
+
+if (config.keepCssVars) {
+    config.clientPolyfillsEntry = require.resolve('./polyfills/css-custom-properties');
+}
 
 export default config;

--- a/packages/arui-scripts/src/configs/app-configs.ts
+++ b/packages/arui-scripts/src/configs/app-configs.ts
@@ -19,13 +19,6 @@ const overridesPath = path.join(CWD, 'arui-scripts.overrides.js');
 const nginxConfFilePath = path.join(CWD, 'nginx.conf');
 const dockerfileFilePath = path.join(CWD, 'Dockerfile');
 
-let aruiPolyfills = null;
-try {
-    aruiPolyfills = require.resolve('arui-feather/polyfills');
-} catch (error) {
-    // just ignore it
-}
-
 type AppConfigs = {
     appPackage: any; // todo;
     name: string;

--- a/packages/arui-scripts/src/configs/polyfills/arui-feather.ts
+++ b/packages/arui-scripts/src/configs/polyfills/arui-feather.ts
@@ -1,4 +1,3 @@
-
 try {
     require('arui-feather/polyfills');
 } catch (error) {

--- a/packages/arui-scripts/src/configs/polyfills/arui-feather.ts
+++ b/packages/arui-scripts/src/configs/polyfills/arui-feather.ts
@@ -1,0 +1,6 @@
+
+try {
+    require('arui-feather/polyfills');
+} catch (error) {
+    // just ignore it
+}

--- a/packages/arui-scripts/src/configs/polyfills/css-custom-properties.ts
+++ b/packages/arui-scripts/src/configs/polyfills/css-custom-properties.ts
@@ -1,0 +1,2 @@
+import 'ie11-custom-properties';
+import './arui-feather';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,6 +3888,7 @@ __metadata:
     fork-ts-checker-webpack-plugin: 5.2.0
     fs-extra: 6.0.1
     gzip-size: 5.1.1
+    ie11-custom-properties: ^4.1.0
     jest: 25.5.4
     jest-snapshot-serializer-class-name-to-string: 1.0.0
     lodash.merge: 4.6.2
@@ -9697,6 +9698,13 @@ fsevents@^1.2.7:
   dependencies:
     postcss: ^7.0.14
   checksum: 437ba4f7c9543db7a007f3968698ae26c966e2c54e34ac08c8f88737d06181ffacc5de8d17435940367135822a98655e3c6c8f70504d22b2f5cbc8e10798f873
+  languageName: node
+  linkType: hard
+
+"ie11-custom-properties@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ie11-custom-properties@npm:4.1.0"
+  checksum: 66a934b4023596f94f135411b8deb42abf896be9df9dc41417bce5b672ed64c9d731549b2273770c96fd2a1cbdfd5f675c4a0a293409d96641f9ec2ebaa4d93b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Добавил условное подключение полифила для css-переменных, если keepCssVars = true 

Не придумал другого способа, как сделать лучше. Есть идеи?