### PR TITLE
fix(css-vars): add polyfill for ie11 when using css vars

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -3036,6 +3036,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "npm:4.1.1"
       ],
       [
+        "ie11-custom-properties",
+        "npm:4.1.0"
+      ],
+      [
         "ieee754",
         "npm:1.1.13"
       ],
@@ -10958,6 +10962,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fork-ts-checker-webpack-plugin", "npm:5.2.0"],
             ["fs-extra", "npm:6.0.1"],
             ["gzip-size", "npm:5.1.1"],
+            ["ie11-custom-properties", "npm:4.1.0"],
             ["jest", "npm:25.5.4"],
             ["jest-snapshot-serializer-class-name-to-string", "npm:1.0.0"],
             ["lodash.merge", "npm:4.6.2"],
@@ -11093,6 +11098,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fork-ts-checker-webpack-plugin", "npm:5.2.0"],
             ["fs-extra", "npm:6.0.1"],
             ["gzip-size", "npm:5.1.1"],
+            ["ie11-custom-properties", "npm:4.1.0"],
             ["jest", "npm:25.5.4"],
             ["jest-snapshot-serializer-class-name-to-string", "npm:1.0.0"],
             ["lodash.merge", "npm:4.6.2"],
@@ -17482,6 +17488,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["icss-utils", "npm:4.1.1"],
             ["postcss", "npm:7.0.32"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["ie11-custom-properties", [
+        ["npm:4.1.0", {
+          "packageLocation": "./.yarn/cache/ie11-custom-properties-npm-4.1.0-503be21d67-66a934b402.zip/node_modules/ie11-custom-properties/",
+          "packageDependencies": [
+            ["ie11-custom-properties", "npm:4.1.0"]
           ],
           "linkType": "HARD",
         }]

--- a/packages/arui-scripts-test/package.json
+++ b/packages/arui-scripts-test/package.json
@@ -6,6 +6,7 @@
         "clientPolyfillsEntry": "./src/polyfills.js",
         "serverEntry": "./src/server",
         "clientEntry": "./src/client",
+        "keepCssVars": false,
         "debug": true
     },
     "scripts": {

--- a/packages/arui-scripts-test/src/style.css
+++ b/packages/arui-scripts-test/src/style.css
@@ -1,3 +1,6 @@
+:root {
+    --color-red: #ff0000;
+}
 body {
     background: aliceblue;
 }
@@ -8,7 +11,7 @@ body {
     margin: 10px;
     font-size: 20px;
     padding: 15px;
-    color: #eee;
+    color: var(--color-red);
     background: linear-gradient(345deg, #aacac2, #3929bb);
     background-size: 400% 400%;
     animation: Insanity 2s ease infinite;

--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -51,6 +51,7 @@
         "fork-ts-checker-webpack-plugin": "5.2.0",
         "fs-extra": "6.0.1",
         "gzip-size": "5.1.1",
+        "ie11-custom-properties": "^4.1.0",
         "jest": "25.5.4",
         "jest-snapshot-serializer-class-name-to-string": "1.0.0",
         "lodash.merge": "4.6.2",
@@ -146,7 +147,10 @@
     },
     "jest": {
         "testRegex": "src/.*/__tests__/.*\\.ts$",
-        "moduleFileExtensions": ["ts", "js"],
+        "moduleFileExtensions": [
+            "ts",
+            "js"
+        ],
         "transform": {
             "^.+\\.tsx?$": "ts-jest"
         }

--- a/packages/arui-scripts/src/commands/util/check-required-files.ts
+++ b/packages/arui-scripts/src/commands/util/check-required-files.ts
@@ -22,7 +22,7 @@ function entryPointToArray(entryPoint: string | string[] | Record<string, string
 const files = [
     ...entryPointToArray(configs.serverEntry),
     ...entryPointToArray(configs.clientEntry),
-    configs.clientPolyfillsEntry
+    ...(Array.isArray(configs.clientPolyfillsEntry) ? configs.clientPolyfillsEntry : [configs.clientPolyfillsEntry]),
 ];
 
 function checkFileWithExtensions(filePath: string, extensions: string[]) {

--- a/packages/arui-scripts/src/configs/app-configs.ts
+++ b/packages/arui-scripts/src/configs/app-configs.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs';
 import merge from 'lodash.merge';
 import validateSettingsKeys from './util/validate-settings-keys';
+import { AppConfigs } from './config-type';
+import { getPolyfills } from './util/get-polyfills';
 
 const CWD = process.cwd();
 
@@ -18,60 +20,6 @@ const yarnLockFilePath = path.join(CWD, 'yarn.lock');
 const overridesPath = path.join(CWD, 'arui-scripts.overrides.js');
 const nginxConfFilePath = path.join(CWD, 'nginx.conf');
 const dockerfileFilePath = path.join(CWD, 'Dockerfile');
-
-let aruiPolyfills = null;
-try {
-    aruiPolyfills = require.resolve('arui-feather/polyfills');
-} catch (error) {
-    // just ignore it
-}
-
-type AppConfigs = {
-    appPackage: any; // todo;
-    name: string;
-    version: string;
-    dockerRegistry: string;
-    baseDockerImage: string;
-
-    cwd: string;
-    appSrc: string;
-    appNodeModules: string;
-    buildPath: string;
-    assetsPath: string;
-    additionalBuildPath: string[];
-    nginxRootPath: string;
-    runFromNonRootUser: boolean;
-    archiveName: string;
-
-    serverEntry: string | string[] | Record<string, string | string[]>;
-    serverOutput: string;
-
-    clientPolyfillsEntry: string | null;
-    clientEntry: string;
-    keepPropTypes: boolean;
-
-    tsconfig: string | null;
-    localNginxConf: string | null;
-    localDockerfile: string | null;
-
-    useTscLoader: boolean;
-    useServerHMR: boolean;
-    useYarn: boolean;
-
-    clientServerPort: number;
-    serverPort: number;
-
-    debug: boolean;
-    hasOverrides: boolean;
-    overridesPath: string;
-
-    componentsTheme: string | undefined;
-    keepCssVars: boolean;
-
-    publicPath: string;
-    serverOutputPath: string;
-    clientOutputPath: string;
-};
 
 /**
  * Базовые настройки. Часть из них может быть переопределена через env либо через package.json
@@ -99,7 +47,7 @@ let config: AppConfigs = {
     serverOutput: 'server.js',
 
     // client compilation configs
-    clientPolyfillsEntry: aruiPolyfills,
+    clientPolyfillsEntry: null,
     clientEntry: path.resolve(absoluteSrcPath, 'index'),
     keepPropTypes: false,
 
@@ -174,10 +122,11 @@ if (process.env.ARUI_SCRIPTS_CONFIG) {
     }
 }
 
-//
+// Эти ключи зависит от других ключей
 // Обновляем их в последнюю очередь
 config.publicPath = `${config.assetsPath}/`;
 config.serverOutputPath = path.resolve(CWD, config.buildPath);
 config.clientOutputPath = path.resolve(CWD, config.buildPath, config.assetsPath);
+config.clientPolyfillsEntry = getPolyfills(config);
 
 export default config;

--- a/packages/arui-scripts/src/configs/config-type.ts
+++ b/packages/arui-scripts/src/configs/config-type.ts
@@ -1,0 +1,46 @@
+export type AppConfigs = {
+    appPackage: any; // todo;
+    name: string;
+    version: string;
+    dockerRegistry: string;
+    baseDockerImage: string;
+
+    cwd: string;
+    appSrc: string;
+    appNodeModules: string;
+    buildPath: string;
+    assetsPath: string;
+    additionalBuildPath: string[];
+    nginxRootPath: string;
+    runFromNonRootUser: boolean;
+    archiveName: string;
+
+    serverEntry: string | string[] | Record<string, string | string[]>;
+    serverOutput: string;
+
+    clientPolyfillsEntry: null | string | string[];
+    clientEntry: string;
+    keepPropTypes: boolean;
+
+    tsconfig: string | null;
+    localNginxConf: string | null;
+    localDockerfile: string | null;
+
+    useTscLoader: boolean;
+    useServerHMR: boolean;
+    useYarn: boolean;
+
+    clientServerPort: number;
+    serverPort: number;
+
+    debug: boolean;
+    hasOverrides: boolean;
+    overridesPath: string;
+
+    componentsTheme: string | undefined;
+    keepCssVars: boolean;
+
+    publicPath: string;
+    serverOutputPath: string;
+    clientOutputPath: string;
+};

--- a/packages/arui-scripts/src/configs/util/__tests__/get-polyfills.tests.ts
+++ b/packages/arui-scripts/src/configs/util/__tests__/get-polyfills.tests.ts
@@ -1,0 +1,80 @@
+import { getPolyfills } from '../get-polyfills';
+import { AppConfigs } from '../../config-type';
+
+describe('getPolyfills', () => {
+    it('should return array when original config contain string as polyfills entry', () => {
+        const appConfig: Partial<AppConfigs> = {
+            clientPolyfillsEntry: 'custom-polyfills',
+        };
+
+        const polyfills = getPolyfills(appConfig as AppConfigs);
+
+        expect(polyfills).toMatchObject([
+            'custom-polyfills',
+        ]);
+    });
+
+    it('should return array when original config contains multiple polyfills entry', () => {
+        const appConfig: Partial<AppConfigs> = {
+            clientPolyfillsEntry: ['custom1', 'custom2'],
+        };
+
+        const polyfills = getPolyfills(appConfig as AppConfigs);
+
+        expect(polyfills).toMatchObject([
+            'custom1',
+            'custom2'
+        ]);
+    });
+
+    it('should return empty array when original config is empty', () => {
+        const appConfig: Partial<AppConfigs> = {
+            clientPolyfillsEntry: null,
+        };
+
+        const polyfills = getPolyfills(appConfig as AppConfigs);
+
+        expect(polyfills).toMatchObject([]);
+    });
+
+    it('should add feather polyfills when original config is empty and feather polyfills is available', () => {
+        const appConfig: Partial<AppConfigs> = {
+            clientPolyfillsEntry: null,
+        };
+        const requireResolve = jest.fn(() => 'feather-polyfills-path');
+
+        const polyfills = getPolyfills(appConfig as AppConfigs, requireResolve as any);
+
+        expect(polyfills).toMatchObject([
+            'feather-polyfills-path'
+        ]);
+        expect(requireResolve).toHaveBeenCalledWith('arui-feather/polyfills')
+    });
+
+    it('should not add feather polyfills when original config has any polyfills', () => {
+        const appConfig: Partial<AppConfigs> = {
+            clientPolyfillsEntry: [],
+        };
+        const requireResolve = jest.fn(() => 'feather-polyfills-path');
+
+        const polyfills = getPolyfills(appConfig as AppConfigs, requireResolve as any);
+
+        expect(polyfills).toMatchObject([]);
+        expect(requireResolve).not.toHaveBeenCalled();
+    });
+
+    it('should add path to ie custom properties when `config.keepCssVars = true`', () => {
+        const appConfig: Partial<AppConfigs> = {
+            keepCssVars: true,
+            clientPolyfillsEntry: []
+        };
+        const requireResolve = jest.fn(() => 'ie11-custom-properties');
+
+        const polyfills = getPolyfills(appConfig as AppConfigs, requireResolve as any);
+
+        expect(requireResolve).toHaveBeenCalledWith('ie11-custom-properties')
+        expect(polyfills).toMatchObject([
+            'ie11-custom-properties'
+        ]);
+    });
+});

--- a/packages/arui-scripts/src/configs/util/get-polyfills.ts
+++ b/packages/arui-scripts/src/configs/util/get-polyfills.ts
@@ -1,0 +1,28 @@
+import { AppConfigs } from '../config-type';
+
+// require.resolve вынесен как параметр функции для того, чтоб это можно было протестировать.
+// на данный момент jest не дает возможности мокать require.resolve https://github.com/facebook/jest/issues/9543
+export function getPolyfills(config: AppConfigs, requireResolve = require.resolve) {
+    const polyfills: string[] = [];
+
+    if (config.clientPolyfillsEntry && Array.isArray(config.clientPolyfillsEntry)) {
+        polyfills.push(...config.clientPolyfillsEntry);
+    } else if (config.clientPolyfillsEntry) {
+        polyfills.push(config.clientPolyfillsEntry);
+    } else {
+        // Для сохранения обратной совместимости нам надо добавлять полифилы из физера только тогда, когда пользователь
+        // не задал свои кастомные полифилы.
+        try {
+            const aruiPolyfills = requireResolve('arui-feather/polyfills');
+            polyfills.push(aruiPolyfills);
+        } catch (error) {
+            // just ignore it
+        }
+    }
+
+    if (config.keepCssVars) {
+        polyfills.push(requireResolve('ie11-custom-properties'));
+    }
+
+    return polyfills;
+}

--- a/packages/arui-scripts/src/configs/webpack.client.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.dev.ts
@@ -22,7 +22,7 @@ const cssModuleRegex = /\.module\.css$/;
 
 function getSingleEntry(clientEntry: string[]) {
     return [
-        configs.clientPolyfillsEntry,
+        ...(Array.isArray(configs.clientPolyfillsEntry) ? configs.clientPolyfillsEntry : [configs.clientPolyfillsEntry]),
         require.resolve('react-hot-loader/patch'),
         `${require.resolve('webpack-dev-server/client')}?/`,
         require.resolve('webpack/hot/dev-server'),

--- a/packages/arui-scripts/src/configs/webpack.client.prod.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.prod.ts
@@ -26,7 +26,10 @@ const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
 
 function getSingleEntry(entryPoint: string[]) {
-    return [configs.clientPolyfillsEntry, ...entryPoint].filter(Boolean) as string[];
+    return [
+        ...(Array.isArray(configs.clientPolyfillsEntry) ? configs.clientPolyfillsEntry : [configs.clientPolyfillsEntry]),
+        ...entryPoint
+    ].filter(Boolean) as string[];
 }
 
 // This is the production configuration.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,6 +3888,7 @@ __metadata:
     fork-ts-checker-webpack-plugin: 5.2.0
     fs-extra: 6.0.1
     gzip-size: 5.1.1
+    ie11-custom-properties: ^4.1.0
     jest: 25.5.4
     jest-snapshot-serializer-class-name-to-string: 1.0.0
     lodash.merge: 4.6.2
@@ -9697,6 +9698,13 @@ fsevents@^1.2.7:
   dependencies:
     postcss: ^7.0.14
   checksum: 437ba4f7c9543db7a007f3968698ae26c966e2c54e34ac08c8f88737d06181ffacc5de8d17435940367135822a98655e3c6c8f70504d22b2f5cbc8e10798f873
+  languageName: node
+  linkType: hard
+
+"ie11-custom-properties@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "ie11-custom-properties@npm:4.1.0"
+  checksum: 66a934b4023596f94f135411b8deb42abf896be9df9dc41417bce5b672ed64c9d731549b2273770c96fd2a1cbdfd5f675c4a0a293409d96641f9ec2ebaa4d93b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
На данный момент у нас по умолчанию сборка идет с сохранением css переменных в скомпиленом бандле. ie11 не умеет работать с переменными без полифила. Автоматически добавлем полифил тогда, когда в коде остаются css переменные.