### PR TITLE
chore(semantic-release): valid prerelease name

### DIFF
--- a/packages/arui-scripts/release.config.js
+++ b/packages/arui-scripts/release.config.js
@@ -15,7 +15,7 @@ module.exports = {
     branches: [
         { name: 'master' },
         { name: '*', channel: betaChannelName, prerelease: true },
-        { name: '*/*', channel: betaChannelName, prerelease: '${name.replace(/\\//g, "-")}' },
+        { name: '*/*', channel: betaChannelName, prerelease: '${name.replace(/[^0-9A-Za-z-]/g, "-")}' },
     ],
     repositoryUrl: 'https://github.com/alfa-laboratory/arui-scripts',
 };


### PR DESCRIPTION
Сейчас не работает публикация новых версий через semantic-release. Названия пререлизных версий строятся из названий веток, и туда затесался недопустимый символ. 
valid name for prerelease is described here: https://semver.org/#spec-item-9