### PR TITLE
feat(*): upgrade minimal nodejs version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -134,7 +134,7 @@
         "brotli-size": "^4.0.0"
     },
     "engines": {
-        "node": ">=8.9.1"
+        "node": ">=12.0.0"
     },
     "scripts": {
         "build": "tsc --project tsconfig-local.json",


### PR DESCRIPTION
Поддержка 10 ноды мешает развитию. Собственно 10 нода уже и не поддерживается.
Это BREAKING CHANGE.