### PR TITLE
fix(nginx): disable server tokens globaly

### DIFF
--- a/packages/alpine-node-nginx/nginx.conf
+++ b/packages/alpine-node-nginx/nginx.conf
@@ -14,6 +14,7 @@ http {
     include                 /etc/nginx/mime.types;
     default_type            application/octet-stream;
 
+    server_tokens off;
     access_log              off;
     keepalive_timeout       65;
     proxy_read_timeout      200;


### PR DESCRIPTION
До этого добавление версии было выключено на уровне server, но многие проекты используют кастомный nginx.conf и эта директива теряется. Поэтому отключаем ее совсем на уровне всего конфига nginx.
ps: доки по server_tokens https://nginx.org/ru/docs/http/ngx_http_core_module.html#server_tokens