### PR TITLE
fix(webpack): restore css minimization in dev

### DIFF
--- a/packages/arui-scripts/src/configs/webpack.client.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.dev.ts
@@ -280,6 +280,7 @@ const webpackClientDev = applyOverrides<webpack.Configuration>(['webpack', 'webp
         hints: false,
     },
     optimization: {
+        minimize: true,
         minimizer: [
             new CssMinimizerPlugin({
                 minimizerOptions: {


### PR DESCRIPTION
В [этом коммите](https://github.com/alfa-laboratory/arui-scripts/commit/204c743b6910d8ca75e60d3163f45f98fe615905) перенесли плагин в другую секцию, но забыли включить минификацию. Из-за этого в новой версии переменные стали дублироваться и случился 🔥 **css-vars-hell** 🔥 